### PR TITLE
Better non alphanumeric bone names.

### DIFF
--- a/gltf_document.cpp
+++ b/gltf_document.cpp
@@ -468,8 +468,11 @@ String GLTFDocument::_gen_unique_name(Ref<GLTFState> state, const String &p_name
 String GLTFDocument::_sanitize_bone_name(const String &name) {
 	String p_name = name.camelcase_to_underscore(true);
 
-	RegEx pattern_del("([^a-zA-Z0-9_ ])+");
-	p_name = pattern_del.sub(p_name, "", true);
+	RegEx pattern_nocolon(":");
+	p_name = pattern_nocolon.sub(p_name, "_", true);
+
+	RegEx pattern_noslash("/");
+	p_name = pattern_noslash.sub(p_name, "_", true);
 
 	RegEx pattern_nospace(" +");
 	p_name = pattern_nospace.sub(p_name, "_", true);
@@ -485,8 +488,10 @@ String GLTFDocument::_sanitize_bone_name(const String &name) {
 
 String GLTFDocument::_gen_unique_bone_name(Ref<GLTFState> state, const GLTFSkeletonIndex skel_i, const String &p_name) {
 
-	const String s_name = _sanitize_bone_name(p_name);
-
+	String s_name = _sanitize_bone_name(p_name);
+	if (s_name.empty()) {
+		s_name = "bone";
+	}
 	String name;
 	int index = 1;
 	while (true) {


### PR DESCRIPTION
1. _gen_unique_bone_name(Ref<GLTFState> state, const GLTFSkeletonIndex skel_i, const String &p_name) won't return an empty string.

2. String GLTFDocument::_sanitize_bone_name(const String &name) will keep Japanese characters. Like: "全ての親".

3. The sanitize function allows  the bone name to be not just alphanumeric. The only required conditions are the ones in add_bone.

> ERR_FAIL_COND(p_name == "" || p_name.find(":") != -1 || p_name.find("/") != -1);